### PR TITLE
Auth: Replace cookie token exchange by POST

### DIFF
--- a/src/app/(auth)/api/auth/callback/route.ts
+++ b/src/app/(auth)/api/auth/callback/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { pages } from "@features/(processes)/_constants/app";
 import { authContext } from "@features/(auth)/_ssr/handlers.auth";
+import { fetchForCookies } from "@features/(auth)/_ssr/handlers.callbackFetch";
 
 export const dynamic = 'force-dynamic'
 
@@ -35,19 +36,7 @@ export async function GET(req: NextRequest) {
         };
 
         // make POST request to backend for session exchange with tokens
-        const response = await fetch(tokenExchangeUrl as string, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify(body)
-        });
-
-        // get session cookie from response
-        const setCookieHeader = response.headers.get('set-cookie');
-
-        if (!setCookieHeader)
-            throw new Error("Missing session cookie in response")
+        const setCookieHeader = await fetchForCookies(tokenExchangeUrl, body)
 
         // build URL to redirect back to FE app
         const parsedRedirectUrl = new URL(redirectUrl as string)

--- a/src/features/(auth)/_ssr/handlers.callbackFetch.ts
+++ b/src/features/(auth)/_ssr/handlers.callbackFetch.ts
@@ -1,0 +1,29 @@
+
+/**
+ * Fetch from API handler to backend service with value included in cookies
+ * @param endpointUrl Endpoint URL
+ * @param body Body for POST request
+ * @param method Optional - method for fetch request
+ * @returns Cookie header from response 
+ */
+export const fetchForCookies = async (endpointUrl: string, body: unknown, method="POST") => {
+    
+    // execute fetch request
+    const response = await fetch(endpointUrl as string, {
+        method,
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(body)
+    });
+
+    // get session cookie from response
+    const setCookieHeader = response.headers.get('set-cookie');
+
+    // check for cookie header
+    if (!setCookieHeader)
+        throw new Error("Missing session cookie in response")
+
+    // return cookie header
+    return setCookieHeader
+}


### PR DESCRIPTION
As we had cross-site issues with authorisation, especially for development, we have changed of push ing authorisation results into our backend identity service and exchange for a session cookie.

Changes:
- auth callback is provided by POST
- cookies (with SID) from the POST is proxied into Next redirect

Dependencies:
- changes at be-identity for processing auth info from request body instead cookies