### PR TITLE
Process IDs Enum

### DIFF
--- a/src/features/(processes)/_constants/app.ts
+++ b/src/features/(processes)/_constants/app.ts
@@ -69,3 +69,16 @@ export const enum processTypes {
   product = "Product",
   unknown = "Unknown type"
 }
+
+
+/**
+ * Enum representing different types of World Cereal processes.
+ * @enum {string}
+ * @readonly
+ * @property {string} WorldCerealDataCrop - Process for world cereal crop extent
+ * @property {string} WorldCerealCropType - Process for world cereal crop type classification
+ */
+export enum UsedCerealProcesses {
+    WorldCerealDataCrop = "worldcereal_crop_extent",
+    WorldCerealCropType = "worldcereal_crop_type"
+}


### PR DESCRIPTION
Was added an `enum` with known Cereals processes. 

## Usage:
```
if(enumIncludes(UsedCerealProcesses, jobFromBackend.processId){
// ... we have a job from process
}
else {
// ... we have a download job
}
```

## TODOs:
- implement detection of job type into the route