### PR TITLE
fix header styling

### DIFF
--- a/src/features/(shared)/_layout/_components/Header/index.tsx
+++ b/src/features/(shared)/_layout/_components/Header/index.tsx
@@ -16,7 +16,7 @@ export const Header = () => {
 	if (error) console.error('Error fetching user info', error);
 
 	return (
-		<AppShellHeader>
+		<AppShellHeader className="worldCereal-Header-shell">
 			<div className="worldCereal-Header">
 				<Title />
 				<div className="worldCereal-Header-tools">

--- a/src/features/(shared)/_layout/_components/Header/style.css
+++ b/src/features/(shared)/_layout/_components/Header/style.css
@@ -1,4 +1,4 @@
-.mantine-AppShell-header {
+.worldCereal-Header-shell.mantine-AppShell-header {
   background: var(--base950);
 }
 


### PR DESCRIPTION
This pull request updates the styling of the application header to use a more specific CSS selector, ensuring that custom styles are only applied to the intended header component.

Styling improvements:

* Updated the `AppShellHeader` component in `index.tsx` to include a new class name `worldCereal-Header-shell`, making the header's custom styles more targeted.
* Modified the CSS selector in `style.css` to `.worldCereal-Header-shell.mantine-AppShell-header`, so the background style is only applied to the specifically classed header, preventing unintended style overrides.