### PR TITLE
Processes list: add loader while loading only

### DIFF
--- a/src/app/index.css
+++ b/src/app/index.css
@@ -43,6 +43,7 @@ input {
 .worldCereal-appContent {
   max-width: var(--pageWidth);
   margin: 0 auto;
+    padding-bottom: 1rem;
 }
 
 /* Buttons */

--- a/src/features/(processes)/_components/ProcessesTable/index.tsx
+++ b/src/features/(processes)/_components/ProcessesTable/index.tsx
@@ -1,8 +1,11 @@
 import { Center, Loader, Table } from '@mantine/core';
 import Record from './Record';
 import './style.css';
-import { processTypes } from '@features/(processes)/_constants/app';
+import { pages, processTypes } from '@features/(processes)/_constants/app';
 import formParams from '@features/(processes)/_constants/generate-custom-products/formParams';
+import Link from 'next/link';
+import { TextHighlight } from '@features/(shared)/_layout/_components/Content/TextHighlight';
+import React from 'react';
 
 type Props = {
 	loading?: boolean;
@@ -96,26 +99,40 @@ export const ProcessesTable = ({ data, loading, forceReloadList }: Props) => {
 		<p>No records</p>
 	);
 
-	return (
-		<>
-			{loading ? (
-				<Center>
-					<Loader />
-				</Center>
-			) : (
-				<Table horizontalSpacing="md" className="worldCereal-ProcessesTable">
-					<Table.Thead>
-						<Table.Tr className="worldCereal-ProcessesTable-row">
-							<Table.Th>ID</Table.Th>
-							<Table.Th>Type</Table.Th>
-							<Table.Th>Created</Table.Th>
-							<Table.Th>Status</Table.Th>
-							<Table.Th></Table.Th>
-						</Table.Tr>
-					</Table.Thead>
-					<Table.Tbody>{rows}</Table.Tbody>
-				</Table>
-			)}
-		</>
-	);
+	if (loading) {
+		return (
+			<Center>
+				<Loader />
+			</Center>
+		);
+	} else if (data.length === 0) {
+		return (
+			<p className="worldCereal-ProcessesTable-noProcess">
+				You have not created any process yet! Go to{' '}
+				<Link href={pages.downloadOfficialProducts.url}>
+					<TextHighlight bold>Download official products</TextHighlight>
+				</Link>{' '}
+				or{' '}
+				<Link href={pages.generateCustomProducts.url}>
+					<TextHighlight bold>Generate custom products</TextHighlight>
+				</Link>
+				.
+			</p>
+		);
+	} else {
+		return (
+			<Table horizontalSpacing="md" className="worldCereal-ProcessesTable">
+				<Table.Thead>
+					<Table.Tr className="worldCereal-ProcessesTable-row">
+						<Table.Th>ID</Table.Th>
+						<Table.Th>Type</Table.Th>
+						<Table.Th>Created</Table.Th>
+						<Table.Th>Status</Table.Th>
+						<Table.Th></Table.Th>
+					</Table.Tr>
+				</Table.Thead>
+				<Table.Tbody>{rows}</Table.Tbody>
+			</Table>
+		);
+	}
 };

--- a/src/features/(processes)/_components/ProcessesTable/style.css
+++ b/src/features/(processes)/_components/ProcessesTable/style.css
@@ -1,5 +1,6 @@
-.worldCereal-ProcessesTable {
-
+.worldCereal-ProcessesTable-noProcess {
+    color: var(--textPrimaryColor);
+    font-size: var(--font-size-md);
 }
 
 .worldCereal-ProcessesTable .mantine-Table-th {

--- a/src/features/pages/processes/ProcessesListClient.tsx
+++ b/src/features/pages/processes/ProcessesListClient.tsx
@@ -19,7 +19,7 @@ export const ProcessesListClient = () => {
 	const url = `/api/jobs/get/list`;
 
 	// Fetch data using SWR with a refresh interval of 15 seconds
-	const { data, mutate, error } = useSWR(url, apiFetcher, {
+	const { data, mutate, error, isLoading } = useSWR(url, apiFetcher, {
 		refreshInterval: 15000,
 	});
 
@@ -37,5 +37,5 @@ export const ProcessesListClient = () => {
 
 	// Render the ProcessesTable component with the fetched data
 	// If no data is available, show a loading state
-	return <ProcessesTable loading={!data?.length} data={data || []} forceReloadList={forceReloadList} />;
+	return <ProcessesTable loading={isLoading} data={data || []} forceReloadList={forceReloadList} />;
 };


### PR DESCRIPTION
This pull request improves the user experience and code clarity in the processes table feature. It enhances the loading and empty state handling, updates the UI to provide more helpful guidance when no processes exist, and introduces minor styling adjustments.

**User experience improvements:**

* Updated the empty state in `ProcessesTable` to display actionable links guiding users to download official products or generate custom products when there are no processes.
* Improved the loading state in `ProcessesTable` by showing a loader when data is being fetched, using the new `isLoading` flag from SWR. [[1]](diffhunk://#diff-6263806b6d9aaed6f8897f550153ba5671b18d45dfda39279a2a6b09ccdd7c4bL22-R22) [[2]](diffhunk://#diff-6263806b6d9aaed6f8897f550153ba5671b18d45dfda39279a2a6b09ccdd7c4bL40-R40) [[3]](diffhunk://#diff-9df7509e541523f532225ec31245ddb7ddbe6b86fe4930d96187c9d5305b2cc5R102-R123)

**Styling updates:**

* Added a new CSS class `.worldCereal-ProcessesTable-noProcess` for the improved empty state message, ensuring consistent styling.
* Added padding to `.worldCereal-appContent` for better layout spacing.

**Code maintenance:**

* Refactored imports and component structure in `ProcessesTable` to support new UI elements and improve code organization. [[1]](diffhunk://#diff-9df7509e541523f532225ec31245ddb7ddbe6b86fe4930d96187c9d5305b2cc5L4-R8) [[2]](diffhunk://#diff-9df7509e541523f532225ec31245ddb7ddbe6b86fe4930d96187c9d5305b2cc5L118-R137)

Resolves: https://github.com/Gisat/app-esaWorldCerealProcesses/issues/191