### PR TITLE
fix: switch release Docker push from Docker Hub to GHCR

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,32 +60,24 @@ jobs:
             echo "new_release_version=" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Convert repository name to Docker Hub name
-        id: convert-repository-name
-        if: steps.release.outputs.new_release_published == 'true'
-        run: |
-          echo "DOCKER_REPO=$(sed 's/^[[:upper:]]/\L&/;s/[[:upper:]]/\L_&/g' <<< '${{ github.event.repository.name }}')" >> "$GITHUB_OUTPUT"
-
       - name: Set up Docker Buildx
         if: steps.release.outputs.new_release_published == 'true'
         uses: docker/setup-buildx-action@v4
-        with:
-          driver: cloud
-          endpoint: gisat/default-builder
 
-      - name: Login to DockerHub
+      - name: Login to GitHub Container Registry
         if: steps.release.outputs.new_release_published == 'true'
         uses: docker/login-action@v4
         with:
-          username: ${{ vars.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PAT }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker meta
         if: steps.release.outputs.new_release_published == 'true'
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: gisat/${{ steps.convert-repository-name.outputs.DOCKER_REPO }}
+          images: ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{version}},value=v${{ steps.release.outputs.new_release_version }},enable=${{ steps.release.outputs.new_release_version != '' }}
             type=semver,pattern={{major}}.{{minor}},value=v${{ steps.release.outputs.new_release_version }},enable=${{ steps.release.outputs.new_release_version != '' }}


### PR DESCRIPTION
## Summary
- Switch release workflow Docker image registry from Docker Hub to GitHub Container Registry

## Changes
- Replace Docker Hub login with GHCR login via GITHUB_TOKEN
- Remove Docker Cloud builder configuration
- Change image namespace from gisat/ to ghcr.io/${{ github.repository }}