### PR TITLE
fix: tolerate GHA cache export failures in Docker workflows

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -69,4 +69,4 @@ jobs:
           load: true
           tags: app-esaworldcereal:test
           cache-from: type=gha,scope=base
-          cache-to: type=gha,scope=base,mode=max
+          cache-to: type=gha,scope=base,mode=max,ignore-error=true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,4 +95,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=base
-          cache-to: type=gha,scope=base,mode=max
+          cache-to: type=gha,scope=base,mode=max,ignore-error=true


### PR DESCRIPTION
## Summary
- Prevents GitHub Actions cache export failures from failing release and PR-check workflows

## Problem
- The latest release workflow (run #27424313085 on merge of #215) failed because the Docker `cache-to: type=gha,mode=max` step returned `not_found` after ~98s of cache export
- GitHub evicts cached layer entries over time, and BuildKit fails when it cannot reconcile a stale cache chain reference
- The Docker image push itself completed successfully — the failure was solely in the cache export, breaking the workflow unnecessarily

## Solution
- Added `ignore-error=true` to the `cache-to` parameter in both workflows
- This follows current Docker best practice (docs.docker.com/build/cache/backends/gha): keep `mode=max` for best cache hit rates, but tolerate cache export failures since the build/push succeeds regardless

## Changes
- `.github/workflows/release.yaml` — `cache-to: type=gha,scope=base,mode=max,ignore-error=true`
- `.github/workflows/pr-checks.yml` — `cache-to: type=gha,scope=base,mode=max,ignore-error=true`
