### PR TITLE
fix: set majority_vote as default postprocess method and improve kernel size validation

### DIFF
--- a/src/app/(processes)/api/jobs/create/from-process/route.ts
+++ b/src/app/(processes)/api/jobs/create/from-process/route.ts
@@ -86,16 +86,19 @@ export async function GET(req: NextRequest) {
 				loggyError('Jobs create from process GET', 'Missing postprocessMethod for crop type');
 				throw new BaseHttpError('Missing postprocessMethod for crop type', 400, ErrorBehavior.SSR);
 			}
-			if (postprocessMethod === customProductsPostprocessMethods.majorityVote && !postprocessKernelSize) {
-				loggyError(
-					'Jobs create from process GET',
-					'Invalid or missing postprocessKernelSize for crop type with majority_vote'
-				);
-				throw new BaseHttpError(
-					'Invalid or missing postprocessKernelSize for crop type with majority_vote',
-					400,
-					ErrorBehavior.SSR
-				);
+			if (postprocessKernelSize !== null && postprocessMethod === customProductsPostprocessMethods.majorityVote) {
+				const parsedSize = Number(postprocessKernelSize);
+				if (isNaN(parsedSize) || parsedSize < 1 || parsedSize > 25 || parsedSize % 2 === 0) {
+					loggyError(
+						'Jobs create from process GET',
+						'Invalid postprocessKernelSize for crop type with majority_vote'
+					);
+					throw new BaseHttpError(
+						'Invalid postprocessKernelSize: must be an odd integer between 1 and 25',
+						400,
+						ErrorBehavior.SSR
+					);
+				}
 			}
 		}
 

--- a/src/features/(processes)/_constants/generate-custom-products/formParams.ts
+++ b/src/features/(processes)/_constants/generate-custom-products/formParams.ts
@@ -128,11 +128,11 @@ const formParams: {
 			{
 				value: customProductsPostprocessMethods.smoothProbabilities,
 				label: 'Smooth probabilities',
-				default: true,
 			},
 			{
 				value: customProductsPostprocessMethods.majorityVote,
 				label: 'Majority vote',
+				default: true,
 			},
 		],
 	},

--- a/src/features/pages/processes/create-custom-products/steps/1/CropTypeOptions/CropTypeOptions.tsx
+++ b/src/features/pages/processes/create-custom-products/steps/1/CropTypeOptions/CropTypeOptions.tsx
@@ -32,7 +32,7 @@ export default function CropTypeOptions() {
 	const kernelSize = getPostProcessKernelSize_customProducts(state);
 
 	// Local state for kernel size input (for immediate feedback)
-	const [localKernelSize, setLocalKernelSize] = useState<string>(kernelSize !== undefined ? String(kernelSize) : '5');
+	const [localKernelSize, setLocalKernelSize] = useState<string>(kernelSize !== undefined ? String(kernelSize) : '3');
 
 	/**
 	 * Initializes default values for orbit state, postprocess method, and kernel size on mount.
@@ -48,15 +48,15 @@ export default function CropTypeOptions() {
 		if (!postprocessMethod) {
 			dispatch({
 				type: WorldCerealStateActionType.CREATE_CUSTOM_PRODUCTS_SET_POSTPROCESS_METHOD,
-				payload: 'smooth_probabilities',
+				payload: 'majority_vote',
 			});
 		}
 		if (kernelSize === undefined) {
 			dispatch({
 				type: WorldCerealStateActionType.CREATE_CUSTOM_PRODUCTS_SET_POSTPROCESS_KERNEL_SIZE,
-				payload: 5,
+				payload: 3,
 			});
-			setLocalKernelSize('5');
+			setLocalKernelSize('3');
 		} else if (String(kernelSize) !== localKernelSize) {
 			setLocalKernelSize(String(kernelSize));
 		}


### PR DESCRIPTION
## Summary
- Set majority_vote as the default postprocess method for custom products (was smooth_probabilities)
- Change default kernel size from 5 to 3
- Improve kernel size validation when majority_vote is selected

## Problem
- The default postprocess method was smooth_probabilities but majority_vote should be the default
- Default kernel size of 5 was not ideal
- Kernel size validation was missing range and parity checks

## Solution
- Swapped `default: true` from smoothProbabilities to majorityVote in form params
- Updated CropTypeOptions default postprocess method and kernel size to majority_vote/3
- Added validation in the API route: kernel size must be an odd integer between 1 and 25

## Changes
- `src/features/(processes)/_constants/generate-custom-products/formParams.ts` — swapped default postprocess method
- `src/features/pages/processes/create-custom-products/steps/1/CropTypeOptions/CropTypeOptions.tsx` — updated defaults
- `src/app/(processes)/api/jobs/create/from-process/route.ts` — improved kernel size validation
