### PR TITLE
fix: hide output file format from custom products step 3

### DIFF
--- a/src/features/pages/processes/create-custom-products/steps/3/CreateProductsStep3Client.tsx
+++ b/src/features/pages/processes/create-custom-products/steps/3/CreateProductsStep3Client.tsx
@@ -123,7 +123,6 @@ export default function CreateProductsStep3Client() {
 							seasonalModelZip={data.seasonalModelZip}
 							landcoverHeadZip={data.landcoverHeadZip}
 							croptypeHeadZip={data.croptypeHeadZip}
-							resultFileFormat={data.format}
 							startDate={data.timeRange?.[0]}
 							endDate={data.timeRange?.[1]}
 							seasonId={data.seasonIds?.[0]}


### PR DESCRIPTION
## Summary
- Remove "Output file format:" attribute from Step 3 of the "Generate custom products" workflow.

## Problem
In Step 3 of "Generate custom products", the "Output file format:" field was visible in the process attributes section. This field is only relevant for "Download official products" jobs and should not appear for custom products.

## Root Cause
`CreateProductsStep3Client.tsx` was passing `resultFileFormat={data.format}` to the shared `ProcessAttributes` component. Since the component renders any attribute with a truthy value, the output file format (e.g., "GTiff") was always displayed regardless of job type.

## Solution
Remove the `resultFileFormat` prop from the `ProcessAttributes` call in `CreateProductsStep3Client.tsx`. The `ProcessAttributes` component already handles hiding attributes when their value is falsy.

## Changes
- `src/features/pages/processes/create-custom-products/steps/3/CreateProductsStep3Client.tsx` — removed `resultFileFormat={data.format}` prop