### PR TITLE
fix: disable step 3 in process Steppers

### DIFF
--- a/src/features/pages/processes/CreateCustomProductsStepper.tsx
+++ b/src/features/pages/processes/CreateCustomProductsStepper.tsx
@@ -23,7 +23,12 @@ export const CreateCustomProductsStepper = ({ children }: { children: React.Reac
 
 	const secondStepDisabled = !processId || activeStep === 3;
 
-	const thirdStepDisabled = !processId || !bboxArr || !endDate;
+	// Step 3 ("Start process") is never clickable in the Stepper. The user reaches it
+	// only via the "Create process" button on step 2, which redirects with a processId.
+	// Clicking the Stepper label here previously navigated to step 3 without a processId,
+	// leaving an empty process that could not actually be started (same bug as issue #245
+	// in the Download official products flow).
+	const thirdStepDisabled = true;
 
 	const setActive = (step: number) => {
 		const targetStep = step + 1;

--- a/src/features/pages/processes/DownloadOfficialProductsStepper.tsx
+++ b/src/features/pages/processes/DownloadOfficialProductsStepper.tsx
@@ -37,8 +37,11 @@ export const DownloadOfficialProductsStepper = ({ children }: { children: React.
 	// Determines if the second step is disabled based on the collection, product, and active step.
 	const secondStepDisabled = !collection || !product || activeStep === 3;
 
-	// Determines if the third step is disabled based on the collection, product, and bounding box.
-	const thirdStepDisabled = !collection || !product || !bboxArr;
+	// Step 3 ("Start process") is never clickable in the Stepper. The user reaches it
+	// only via the "Create process" button on step 2, which redirects with a jobKey.
+	// Clicking the Stepper label here previously navigated to step 3 without a jobKey,
+	// leaving an empty process that could not actually be started (issue #245).
+	const thirdStepDisabled = true;
 
 	/**
 	 * Navigates to the specified step in the process, forwarding the current URL state


### PR DESCRIPTION
## Summary
- Make the third "Start process" step non-clickable in both process Steppers (`DownloadOfficialProductsStepper`, `CreateCustomProductsStepper`).

## Problem
On step 2, the Stepper's "Start process" step became clickable as soon as the bbox, product/collection (and `processId` for the custom flow) were all present. Clicking it navigated to step 3 without forwarding the `jobKey`/`processId`, so step 3 rendered with no process loaded and the in-page "Start process" button was enabled against `/api/jobs/start/undefined` — leading to the "empty process that cannot be started" reported in #245.

## Solution
Step 3 is reachable only via the "Create process" button on step 2, which already redirects to step 3 with the freshly-minted `jobKey`/`processId` in the URL.

## Changes
- `src/features/pages/processes/DownloadOfficialProductsStepper.tsx` — `thirdStepDisabled` is now always `true`.
- `src/features/pages/processes/CreateCustomProductsStepper.tsx` — same change for the generate-custom-products flow (same bug class).

Closes #245
